### PR TITLE
feat: add MAKE_CUSTOM_MIRROR environment variable to use GNU mirror #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ asdf global make latest
 make --version
 ```
 
+## Use gpg mirror
+
+If download failed because of timeout, you can try with a
+[mirror](https://www.gnu.org/prep/ftp.html) using `MAKE_CUSTOM_MIRROR`, for
+example:
+
+```shell
+MAKE_CUSTOM_MIRROR= asdf install make latest
+```
+
 # Use
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -4,7 +4,7 @@ set -euo pipefail
 GNU_TOOL="make"
 #GNU_FTP=https://ftpmirror.gnu.org
 #GNU_KEYRING=$GNU_FTP/gnu/gnu-keyring.gpg
-GNU_FTP=https://ftp.gnu.org/gnu
+GNU_FTP=${MAKE_CUSTOM_MIRROR:-https://ftp.gnu.org/gnu}
 GNU_KEYRING=$GNU_FTP/gnu-keyring.gpg
 TOOL_NAME="make"
 TOOL_TEST="make --version"


### PR DESCRIPTION
## Context

Closes #23

This MR adds the ability to use a [GNU mirror](https://www.gnu.org/prep/ftp.html) via the MAKE_CUSTOM_MIRROR environment variable to prevent timeout errors.